### PR TITLE
데이터베이스로 카산드라 사용

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN npm install
 #
 COPY config.yaml .
 EXPOSE 7231
-CMD sed -i "s~MEDIAWIKI_APIS_URI~${MEDIAWIKI_APIS_URI:-https://femiwiki.com/api.php}~" /srv/restbase/config.yaml &&\
-    sed -i "s~PARSOID_URI~${PARSOID_URI:-http://parsoid:8000}~" /srv/restbase/config.yaml &&\
-    sed -i "s~MEDIAWIKI_APIS_DOMAIN~${MEDIAWIKI_APIS_DOMAIN:-femiwiki.com}~" /srv/restbase/config.yaml &&\
+
+COPY run /usr/local/bin/
+CMD /usr/local/bin/run &&\
     node server.js

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 Dockerized restbase server [![Docker Hub Status]][Docker Hub Link]
 ========
 
-[페미위키]를 위한 [RESTBase] Docker Image
+[페미위키]를 위해 데이터베이스로 [Cassandra]를 사용하도록 하는 등의 설정이 된 [RESTBase] Docker Image.
 
 ## 실행하기
 
-다음 명령으로 RESTBase를 7231 포트로 열 수 있습니다.
+데이터베이스가 준비되어 있다면, 다음과 같은 명령으로 RESTBase를 7231 포트로 열 수 있습니다.
 
 ```sh
 docker run -p 7231:7231 [-e MEDIAWIKI_APIS_URI=...] [-e MEDIAWIKI_APIS_DOMAIN=...] [-e PARSOID_URI=...] femiwiki/restbase
@@ -15,11 +15,22 @@ docker run -p 7231:7231 [-e MEDIAWIKI_APIS_URI=...] [-e MEDIAWIKI_APIS_DOMAIN=..
 
 ### 환경 변수
 
-| 이름 | 기본값 | 설명 |
+이름 | 기본값 | 설명
 --|--|--
-MEDIAWIKI_APIS_URI | `https://femiwiki.com/api.php` | 위키의 API path. Container 안에서 접근할 수 있는 것이어야 합니다.
+MEDIAWIKI_APIS_URI | `http://http/api.php` | 위키의 API path. (도커 컨테이너 안에서 접근할 수 있어야 함)
 MEDIAWIKI_APIS_DOMAIN | `femiwiki.com` | 위키의 [LocalSettings.php](https://www.mediawiki.org/wiki/Manual:LocalSettings.php)에서 정의한 `$wgVirtualRestConfig['modules']['restbase']['domain']`과 동일한 값 ([자세한 설명](https://www.mediawiki.org/wiki/RESTBase/Installation#Configuration))
-PARSOID_URI | `http://parsoid:8000` | Parsoid의 URI. Container 안에서 접근할 수 있는 것이어야 합니다.
+PARSOID_URI | `http://parsoid:8000` | Parsoid의 URI. (도커 컨테이너 안에서 접근할 수 있어야 함)
+
+## secret.php
+
+콘테이너의 `/a/secret.php` 파일에서 다음 값이 읽혀 사용됩니다.
+(정규식을 통하여 읽을 뿐 실제 php를 해석하는 것이 아니므로 여러번 정의하거나 하는 등의 상황에서는 문제가 발생할 수 있습니다)
+
+이름 | 설명
+--|--
+`$wgRESTBaseCassandraServer` | 접속할 Cassandra의 URI. (도커 컨테이너 안에서 접근할 수 있어야 함)
+`$wgRESTBaseCassandraUser` | Cassandra에 접속할 때 사용할 사용자 이름
+`$wgRESTBaseCassandraPassword` | Cassandra에 접속할 때 사용할 사용자 암호
 
 ## 빌드
 
@@ -40,5 +51,6 @@ of the [GNU Affero General Public License v3.0] or any later version. See
 [Docker Hub Link]: https://hub.docker.com/r/femiwiki/restbase/
 [페미위키]: https://femiwiki.com
 [RESTBase]: https://www.mediawiki.org/wiki/RESTBase
+[Cassandra]: http://cassandra.apache.org/
 [GNU Affero General Public License v3.0]: LICENSE
 [COPYRIGHT]: COPYRIGHT

--- a/config.yaml
+++ b/config.yaml
@@ -37,12 +37,14 @@ services:
                   parsoid:
                     host: PARSOID_URI
                   table:
-                    backend: sqlite
-                    dbname: db.sqlite3
-                    pool_idle_timeout: 20000
-                    retry_delay: 250
-                    retry_limit: 10
-                    show_sql: false
+                    backend: cassandra
+                    hosts: [DB_HOSTNAME]
+                    keyspace: femiwiki
+                    username: DB_USERNAME
+                    password: DB_PASSWORD
+                    storage_groups:
+                      - name: default.group.local
+                        domains: /./
                   mobileapps:
                     host: https://appservice.wmflabs.org
                   purged_cache_control: s-maxage=0, max-age=86400

--- a/run
+++ b/run
@@ -1,29 +1,29 @@
 #!/usr/bin/env node
 
+const secretFile = '/a/secret.php';
 const configFile = '/srv/restbase/config.yaml';
 
-const fs = require('fs');
+main();
 
-fs.readFile('/a/secret.php', 'utf8', (err, data) => {
-  if (err) { throw err; }
+async function main() {
+  const fs = require('fs').promises;
 
-  // Roughly import /a/secret.php
-  const hostname = data.match(/^\$wgRESTBaseCassandraServer\s*=\s*['"](.+)['"]\s*\;/m)[1];
-  const username = data.match(/^\$wgRESTBaseCassandraUser\s*=\s*['"](.+)['"]\s*\;/m)[1];
-  const password = data.match(/^\$wgRESTBaseCassandraPassword\s*=\s*['"](.+)['"]\s*\;/m)[1];
+  // Read secrets roughly from /a/secret.php
+  const secret = await fs.readFile(secretFile, 'utf8');
+
+  const hostname = secret.match(/^\$wgRESTBaseCassandraServer\s*=\s*['"](.+)['"]\s*\;/m)[1];
+  const username = secret.match(/^\$wgRESTBaseCassandraUser\s*=\s*['"](.+)['"]\s*\;/m)[1];
+  const password = secret.match(/^\$wgRESTBaseCassandraPassword\s*=\s*['"](.+)['"]\s*\;/m)[1];
 
   // Update config.yaml
-  fs.readFile(configFile, 'utf8', (err, data) => {
-    data = data.replace(/DB_HOSTNAME/g, hostname);
-    data = data.replace(/DB_USERNAME/g, username);
-    data = data.replace(/DB_PASSWORD/g, password);
-    data = data.replace(/MEDIAWIKI_APIS_URI/g, process.env.MEDIAWIKI_APIS_URI || 'http://http/api.php');
-    data = data.replace(/PARSOID_URI/g, process.env.PARSOID_URI || 'http://parsoid:8000');
-    data = data.replace(/MEDIAWIKI_APIS_DOMAIN/g, process.env.MEDIAWIKI_APIS_DOMAIN || 'femiwiki.com');
+  let config = await fs.readFile(configFile, 'utf8');
 
-    fs.writeFile(configFile, data, err => {
-      if (err) { throw err; }
-    });
-  });
-});
+  config = config.replace(/DB_HOSTNAME/g, hostname);
+  config = config.replace(/DB_USERNAME/g, username);
+  config = config.replace(/DB_PASSWORD/g, password);
+  config = config.replace(/MEDIAWIKI_APIS_URI/g, process.env.MEDIAWIKI_APIS_URI || 'http://http/api.php');
+  config = config.replace(/PARSOID_URI/g, process.env.PARSOID_URI || 'http://parsoid:8000');
+  config = config.replace(/MEDIAWIKI_APIS_DOMAIN/g, process.env.MEDIAWIKI_APIS_DOMAIN || 'femiwiki.com');
 
+  await fs.writeFile(configFile, config);
+}

--- a/run
+++ b/run
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+const configFile = '/srv/restbase/config.yaml';
+
+const fs = require('fs');
+
+fs.readFile('/a/secret.php', 'utf8', (err, data) => {
+  if (err) throw err;
+
+  // Roughly import /a/secret.php
+  const hostname = data.match(/^\$wgRESTBaseCassandraServer\s*=\s*['"](.+)['"]\s*\;/m)[1];
+  const username = data.match(/^\$wgRESTBaseCassandraUser\s*=\s*['"](.+)['"]\s*\;/m)[1];
+  const password = data.match(/^\$wgRESTBaseCassandraPassword\s*=\s*['"](.+)['"]\s*\;/m)[1];
+
+  // Update config.yaml
+  fs.readFile(configFile, 'utf8', (err, data) => {
+    data = data.replace(/DB_HOSTNAME/g, hostname);
+    data = data.replace(/DB_USERNAME/g, username);
+    data = data.replace(/DB_PASSWORD/g, password);
+    data = data.replace(/MEDIAWIKI_APIS_URI/g, process.env.MEDIAWIKI_APIS_URI || 'http://http/api.php');
+    data = data.replace(/PARSOID_URI/g, process.env.PARSOID_URI || 'http://parsoid:8000');
+    data = data.replace(/MEDIAWIKI_APIS_DOMAIN/g, process.env.MEDIAWIKI_APIS_DOMAIN || 'femiwiki.com');
+
+    fs.writeFile(configFile, data, (err) => {
+      if (err) throw err;
+    });
+  });
+});
+

--- a/run
+++ b/run
@@ -5,7 +5,7 @@ const configFile = '/srv/restbase/config.yaml';
 const fs = require('fs');
 
 fs.readFile('/a/secret.php', 'utf8', (err, data) => {
-  if (err) throw err;
+  if (err) { throw err; }
 
   // Roughly import /a/secret.php
   const hostname = data.match(/^\$wgRESTBaseCassandraServer\s*=\s*['"](.+)['"]\s*\;/m)[1];
@@ -22,7 +22,7 @@ fs.readFile('/a/secret.php', 'utf8', (err, data) => {
     data = data.replace(/MEDIAWIKI_APIS_DOMAIN/g, process.env.MEDIAWIKI_APIS_DOMAIN || 'femiwiki.com');
 
     fs.writeFile(configFile, data, (err) => {
-      if (err) throw err;
+      if (err) { throw err; }
     });
   });
 });

--- a/run
+++ b/run
@@ -21,7 +21,7 @@ fs.readFile('/a/secret.php', 'utf8', (err, data) => {
     data = data.replace(/PARSOID_URI/g, process.env.PARSOID_URI || 'http://parsoid:8000');
     data = data.replace(/MEDIAWIKI_APIS_DOMAIN/g, process.env.MEDIAWIKI_APIS_DOMAIN || 'femiwiki.com');
 
-    fs.writeFile(configFile, data, (err) => {
+    fs.writeFile(configFile, data, err => {
       if (err) { throw err; }
     });
   });

--- a/run
+++ b/run
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+'use strict'
+
+const fs = require('fs').promises;
 
 const SECRET_FILE = '/a/secret.php';
 const CONFIG_FILE = '/srv/restbase/config.yaml';
@@ -6,23 +9,23 @@ const CONFIG_FILE = '/srv/restbase/config.yaml';
 main();
 
 async function main() {
-  const fs = require('fs').promises;
+  // Start reading files
+  const secretPromise = fs.readFile(SECRET_FILE, 'utf8');
+  const configPromise = fs.readFile(CONFIG_FILE, 'utf8');
 
-  // Read secrets roughly from /a/secret.php
-  const secret = await fs.readFile(SECRET_FILE, 'utf8');
-
+  // Extract secrets from 'secret.php' using RegExp
+  const secret = await secretPromise;
   const hostname = secret.match(/^\$wgRESTBaseCassandraServer\s*=\s*['"](.+)['"]\s*\;/m)[1];
   const username = secret.match(/^\$wgRESTBaseCassandraUser\s*=\s*['"](.+)['"]\s*\;/m)[1];
   const password = secret.match(/^\$wgRESTBaseCassandraPassword\s*=\s*['"](.+)['"]\s*\;/m)[1];
 
   // Update config.yaml
-  let config = await fs.readFile(CONFIG_FILE, 'utf8');
-
+  let config = await configPromise;
   config = config.replace(/DB_HOSTNAME/g, hostname);
   config = config.replace(/DB_USERNAME/g, username);
   config = config.replace(/DB_PASSWORD/g, password);
-  config = config.replace(/MEDIAWIKI_APIS_URI/g, process.env.MEDIAWIKI_APIS_URI || 'http://http/api.php');
   config = config.replace(/PARSOID_URI/g, process.env.PARSOID_URI || 'http://parsoid:8000');
+  config = config.replace(/MEDIAWIKI_APIS_URI/g, process.env.MEDIAWIKI_APIS_URI || 'http://http/api.php');
   config = config.replace(/MEDIAWIKI_APIS_DOMAIN/g, process.env.MEDIAWIKI_APIS_DOMAIN || 'femiwiki.com');
 
   await fs.writeFile(CONFIG_FILE, config);

--- a/run
+++ b/run
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-const secretFile = '/a/secret.php';
-const configFile = '/srv/restbase/config.yaml';
+const SECRET_FILE = '/a/secret.php';
+const CONFIG_FILE = '/srv/restbase/config.yaml';
 
 main();
 
@@ -9,14 +9,14 @@ async function main() {
   const fs = require('fs').promises;
 
   // Read secrets roughly from /a/secret.php
-  const secret = await fs.readFile(secretFile, 'utf8');
+  const secret = await fs.readFile(SECRET_FILE, 'utf8');
 
   const hostname = secret.match(/^\$wgRESTBaseCassandraServer\s*=\s*['"](.+)['"]\s*\;/m)[1];
   const username = secret.match(/^\$wgRESTBaseCassandraUser\s*=\s*['"](.+)['"]\s*\;/m)[1];
   const password = secret.match(/^\$wgRESTBaseCassandraPassword\s*=\s*['"](.+)['"]\s*\;/m)[1];
 
   // Update config.yaml
-  let config = await fs.readFile(configFile, 'utf8');
+  let config = await fs.readFile(CONFIG_FILE, 'utf8');
 
   config = config.replace(/DB_HOSTNAME/g, hostname);
   config = config.replace(/DB_USERNAME/g, username);
@@ -25,5 +25,5 @@ async function main() {
   config = config.replace(/PARSOID_URI/g, process.env.PARSOID_URI || 'http://parsoid:8000');
   config = config.replace(/MEDIAWIKI_APIS_DOMAIN/g, process.env.MEDIAWIKI_APIS_DOMAIN || 'femiwiki.com');
 
-  await fs.writeFile(configFile, config);
+  await fs.writeFile(CONFIG_FILE, config);
 }


### PR DESCRIPTION
- 기존에 데이터베이스 설정이 기본값(SQLite)이었던 것을 카산드라로 바꾸고 미디어위키 서버와 통신하도록 변경
- secret.php을 볼륨으로 불러오게 하여 카산드라 접속에 필요한 민감 정보들을 사용함
- 도커파일 일부가 길어져 run 스크립트로 분리

#### 관련 이슈

- https://github.com/femiwiki/femiwiki/issues/52