### PR TITLE
Dockerfile: Do not update yarn.lock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /srv/restbase
 RUN apk add --no-cache --virtual .build-deps \
     git python make g++
 COPY package.json ./
-RUN yarn
+RUN yarn --frozen-lockfile
 
 # Remove build dependencies
 RUN apk del .build-deps


### PR DESCRIPTION
디펜던시 설치할 때 `yarn.lock` 과 정확하게 동일하게 설치하도록 설정

###### Reference
- https://classic.yarnpkg.com/en/docs/cli/install/#toc-yarn-install